### PR TITLE
design: 페이지 네비게이션 헤더에 웨이브 모양 추가

### DIFF
--- a/components/layout/Footer.module.scss
+++ b/components/layout/Footer.module.scss
@@ -1,0 +1,34 @@
+.footer {
+  padding: 32px;
+  background-color: black;
+
+  h1 {
+    margin-bottom: 12px;
+    color: white;
+    font-size: 16px;
+    letter-spacing: 2.1px;
+  }
+
+  ul {
+    flex-direction: column;
+    padding: 0;
+    list-style: none;
+
+    li {
+      display: block;
+      margin-bottom: 14px;
+
+      a {
+        padding: 4px 12px 6px 0;
+        color: #a8a5a5;
+        font-size: 14px;
+        letter-spacing: 2.1px;
+        line-height: 1.7px;
+      }
+
+      a:hover {
+        color: white;
+      }
+    }
+  }
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,27 @@
+import styles from "./Footer.module.scss";
+import React from "react";
+
+export default function Footer(): React.ReactElement {
+  return (
+    <footer className={styles.footer}>
+      <h1>Profile</h1>
+      <ul>
+        <li>
+          <a href="https://github.com/OHHAKO" target="__blank">
+            github
+          </a>
+        </li>
+        <li>
+          <a href="https://medium.com/@khk0503" target="__blank">
+            medium
+          </a>
+        </li>
+        <li>
+          <a href="https://instagram.com/kimhrkeon?igshid=YmMyMTA2M2Y=" target="__blank">
+            instagram
+          </a>
+        </li>
+      </ul>
+    </footer>
+  );
+}

--- a/components/layout/Layout.module.scss
+++ b/components/layout/Layout.module.scss
@@ -47,31 +47,3 @@
     display: block;
   }
 }
-
-.footer {
-  padding: 32px;
-
-  ul {
-    flex-direction: row;
-    padding: 0;
-    list-style: none;
-
-    li {
-      display: inline;
-      padding: 4px 12px 6px;
-      margin: 0 4px 0 0;
-      background: black;
-      border-radius: 7px;
-
-      a {
-        color: white;
-        letter-spacing: 2.1px;
-        line-height: 1.7px;
-      }
-    }
-
-    li:hover {
-      background: rgba(0, 0, 0, 0.6);
-    }
-  }
-}

--- a/components/layout/Layout.module.scss
+++ b/components/layout/Layout.module.scss
@@ -1,21 +1,26 @@
 .header {
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  padding: 32px 0;
+  .titleWrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    padding-top: 20px;
+    background-color: rgba(0, 0, 0);
+    color: white;
+
+    @media screen and (min-width: 768px) {
+      padding-top: 40px;
+    }
+  }
 
   .title {
     padding: 6px 16px;
     margin-bottom: 4px;
-    background-color: white;
     border-radius: 8px;
     font-size: 24px;
     font-weight: bold;
     letter-spacing: 1.8px;
-    line-height: 1.4em;
     text-align: center;
 
     .author {
@@ -23,7 +28,7 @@
     }
 
     @media screen and (min-width: 768px) {
-      font-size: 48px;
+      font-size: 40px;
     }
   }
 
@@ -36,6 +41,10 @@
       margin-top: -5px;
       margin-right: 16px;
     }
+  }
+
+  svg {
+    display: block;
   }
 }
 

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -1,3 +1,4 @@
+import Footer from "./Footer";
 import styles from "./Layout.module.scss";
 import manul from "public/assets/pallas.png";
 import Head from "next/head";
@@ -38,25 +39,7 @@ export default function Layout({ children }: Props): React.ReactElement {
 
       <main>{children}</main>
 
-      <footer className={styles.footer}>
-        <ul>
-          <li>
-            <a href="https://github.com/OHHAKO" target="__blank">
-              Git
-            </a>
-          </li>
-          <li>
-            <a href="https://medium.com/@khk0503" target="__blank">
-              Medium
-            </a>
-          </li>
-          <li>
-            <a href="https://instagram.com/kimhrkeon?igshid=YmMyMTA2M2Y=" target="__blank">
-              Instagram
-            </a>
-          </li>
-        </ul>
-      </footer>
+      <Footer />
     </>
   );
 }

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -18,13 +18,22 @@ export default function Layout({ children }: Props): React.ReactElement {
       </Head>
 
       <header className={styles.header}>
-        <h1 className={styles.title}>
-          <Link href="/">User interface estudio</Link>
-        </h1>
-        <div className={styles.imgWrapper}>
-          <Image src={manul} alt="picture" width={120} height={80} />
-          <span className={styles.author}>by Hako</span>
+        <div className={styles.titleWrapper}>
+          <h1 className={styles.title}>
+            <Link href="/">User Interface Estudio</Link>
+          </h1>
+          <div className={styles.imgWrapper}>
+            <Image src={manul} alt="picture" width={120} height={80} />
+            <span className={styles.author}>by Hako</span>
+          </div>
         </div>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 1440 220">
+          <path
+            fill="black"
+            fillOpacity="1"
+            d="M0,96L120,117.3C240,139,480,181,720,186.7C960,192,1200,160,1320,144L1440,128L1440,0L1320,0C1200,0,960,0,720,0C480,0,240,0,120,0L0,0Z"
+          ></path>
+        </svg>
       </header>
 
       <main>{children}</main>


### PR DESCRIPTION
## What?
- 헤더에 웨이브 장식을 svg 컴포넌트로 추가
- 푸터에 타이틀 추가 및 심플 디자인 변경 

## How?
- 웨이브를 만들어주는 사이트에서 svg 값 가져오기 (https://getwaves.io/)

## ScreenShot?
모바일 너비 브라우저

<img width="494" alt="스크린샷 2022-10-02 오후 1 27 40" src="https://user-images.githubusercontent.com/29711964/193437865-300b2b71-092b-48ba-9a2b-70ddc803685c.png">
