### PR TITLE
feat: 사이트 구조화된 데이터 제공

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,41 @@
 import Layout from "components/layout/Layout";
 import type { AppProps } from "next/app";
+import Script from "next/script";
 import React from "react";
+
 import { ParallaxProvider } from "react-scroll-parallax";
 import "styles/base.scss";
+
+const structuredData = {
+  "@context": "http://schema.org/",
+  "@type": "People",
+  name: "User interface estudio", // 사이트 이름
+  description: "This page is for test good user interface and web performance", // 설명
+  url: "https://front-action-boilerplate-ohhako.vercel.app/",
+  publisher: {
+    "@type": "People",
+    name: "Hako Kim",
+  },
+  sameAs: ["https://github.com/OHHAKO", "https://medium.com/@khk0503"],
+};
 
 export default function JudgementSimulatorApp({
   Component,
   pageProps,
 }: AppProps): React.ReactElement {
   return (
-    <ParallaxProvider>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </ParallaxProvider>
+    <>
+      <Script
+        id="web-json-ld"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData),
+        }}
+      ></Script>
+      <ParallaxProvider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </ParallaxProvider>
+    </>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,5 @@
 import Layout from "components/layout/Layout";
 import type { AppProps } from "next/app";
-import Script from "next/script";
 import React from "react";
 
 import { ParallaxProvider } from "react-scroll-parallax";
@@ -25,12 +24,12 @@ export default function JudgementSimulatorApp({
 }: AppProps): React.ReactElement {
   return (
     <>
-      <Script
+      <script
         id="web-json-ld"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(structuredData),
         }}
-      ></Script>
+      ></script>
       <ParallaxProvider>
         <Layout>
           <Component {...pageProps} />


### PR DESCRIPTION
## What?
- 사이트에 구조화된 데이터 스크립트 추가 (_app.tsx)

## Why?
- [네이버검색 결과 사이트에 연관채널 추가하기 작업 기록](https://www.notion.so/DT-305781abc9f6408b91b25f4c79c2f192?pvs=4)
- 네이버에서 지원하는 '연관 채널'을 위해 시작했으나 구글같은 검색 엔진에서 검색 결과를 최적화 하는거 같다. 공식적인 정보로 보이게끔 신뢰를 주고 다른 채널 마켓팅 퍼널로 쓸 수 있어 유용하다.

## How?
스크립트 스니펫 추가시 next/script API를 사용하려고 했으나 Next.js 11부터 지원. ([관련 문서](https://nextjs.org/docs/api-reference/next/script)) 버전 업데이트 후 재시도